### PR TITLE
Using the same git repo to build Docker images

### DIFF
--- a/selenium-node-chrome-debug.yaml
+++ b/selenium-node-chrome-debug.yaml
@@ -19,7 +19,7 @@ objects:
       contextDir: selenium-node-chrome-debug
       type: Git
       git:
-        uri: https://github.com/jemacom/selenium-openshift-templates
+        uri: https://github.com/ddavison/selenium-openshift-templates
         ref: master
     strategy:
       type: Docker

--- a/selenium-node-chrome.yaml
+++ b/selenium-node-chrome.yaml
@@ -19,7 +19,7 @@ objects:
       contextDir: selenium-node-chrome
       type: Git
       git:
-        uri: https://github.com/jr00n/selenium-os
+        uri: https://github.com/ddavison/selenium-openshift-templates
         ref: master
     strategy:
       type: Docker

--- a/selenium-node-firefox-debug.yaml
+++ b/selenium-node-firefox-debug.yaml
@@ -19,7 +19,7 @@ objects:
       contextDir: selenium-node-firefox-debug
       type: Git
       git:
-        uri: https://github.com/jr00n/selenium-os
+        uri: https://github.com/ddavison/selenium-openshift-templates
         ref: master
     strategy:
       type: Docker

--- a/selenium-node-firefox.yaml
+++ b/selenium-node-firefox.yaml
@@ -19,7 +19,7 @@ objects:
       contextDir: selenium-node-firefox
       type: Git
       git:
-        uri: https://github.com/jr00n/selenium-os
+        uri: https://github.com/ddavison/selenium-openshift-templates
         ref: master
     strategy:
       type: Docker


### PR DESCRIPTION
It's better to use one git repo to build Docker images. That's will save us from breaking changes or removes that might happen on the other repos.