### PR TITLE
Openshift 4.5.x and Selenium 4.0.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/README.md
+++ b/README.md
@@ -1,17 +1,68 @@
 Selenium OpenShift Templates
 ===
 
-> OpenShift Templates used for a Scalable Selenium infrastructure
+> OpenShift Templates used for a Scalable Selenium infrastructure and these templates tested on OpenShift 4.5.8.
 
 Usage
 ===
 
+
 ```bash
 $ oc create -f selenium-hub.yaml
 $ oc create -f selenium-node-chrome.yaml
+$ oc create -f selenium-node-firefox.yaml
+$ oc process selenium-hub | oc create -f -
+$ oc process selenium-node-chrome | oc create -f -
+$ oc process selenium-node-firefox | oc create -f -
 ```
 
-In case you want to have VNC access to your chrome node, you need to add node chrome debug
+Once all pods up and running and check the grid status with the following endpoint and you should see following output.
+Hub status url: https://OCP-ROUTE/wd/hub/status
+
+**Note:** Please replace OCP-ROUTE based on your environment.
+
+```
+{
+  "value": {
+    "ready": true,
+    "message": "Selenium Grid ready.",
+    "nodes": [
+      {
+        "id": "72eaea16-1c0a-44b2-987f-c71cc36d6a77",
+        "uri": "http:\u002f\u002f10.254.16.254:5555",
+        "maxSessions": 1,
+        "stereotypes": [
+          {
+            "capabilities": {
+              "browserName": "chrome"
+            },
+            "count": 1
+          }
+        ],
+        "sessions": [
+        ]
+      },
+      {
+        "id": "ee1d92e8-52cd-40a0-9516-cb4c424da8d8",
+        "uri": "http:\u002f\u002f10.254.17.0:5555",
+        "maxSessions": 1,
+        "stereotypes": [
+          {
+            "capabilities": {
+              "browserName": "firefox"
+            },
+            "count": 1
+          }
+        ],
+        "sessions": [
+        ]
+      }
+    ]
+  }
+}
+```
+
+In case you want to have VNC access to your chrome node, you need to add node chrome debug and you can follow same steps for firefox node as well.
 ```
 $ oc create -f selenium-node-chrome-debug.yaml
 ```

--- a/selenium-hub.yaml
+++ b/selenium-hub.yaml
@@ -24,6 +24,14 @@ objects:
       port: 5555
       targetPort: 5555
       protocol: TCP
+    - name: publish
+      port: 4442
+      targetPort: 4442
+      protocol: TCP
+    - name: subscribe
+      port: 4443
+      targetPort: 4443
+      protocol: TCP
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -60,7 +68,7 @@ objects:
             value: ${GRID_MAX_SESSION}
           - name: GRID_UNREGISTER_IF_STILL_DOWN_AFTER
             value: ${GRID_UNREGISTER_IF_STILL_DOWN_AFTER}
-          image: selenium/hub
+          image: selenium/hub:4.0.0
           name: master
           ports:
           - containerPort: 4444

--- a/selenium-node-chrome-debug.yaml
+++ b/selenium-node-chrome-debug.yaml
@@ -7,35 +7,6 @@ metadata:
     iconClass: "icon-selenium"
     tags: "selenium,node,chrome,debug"
 objects:
-- kind: BuildConfig
-  apiVersion: v1
-  metadata:
-    name: selenium-node-chrome-debug
-  spec:
-    triggers:
-    - type: ConfigChange
-      configChange: {}
-    source:
-      contextDir: selenium-node-chrome-debug
-      type: Git
-      git:
-        uri: https://github.com/ddavison/selenium-openshift-templates
-        ref: master
-    strategy:
-      type: Docker
-      DockerStrategy: {}
-    output:
-      to:
-        kind: ImageStreamTag
-        name: selenium-node-chrome-debug:latest
-- kind: ImageStream
-  apiVersion: v1
-  metadata:
-    name: selenium-node-chrome-debug
-  spec:
-    dockerImageRepository: ''
-    tags:
-    - name: latest
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -43,16 +14,6 @@ objects:
   spec:
     strategy:
       type: Recreate
-    triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-        - master
-        from:
-          kind: ImageStreamTag
-          name: selenium-node-chrome-debug:latest
-    - type: ConfigChange
     replicas: 1
     selector:
       browser: chrome
@@ -74,7 +35,13 @@ objects:
             value: ${HUB_PORT_4444_TCP_PORT}
           - name: REMOTE_HOST
             value: ${REMOTE_HOST}
-          image: selenium/node-chrome-debug
+          - name: SE_EVENT_BUS_HOST
+            value: ${SE_EVENT_BUS_HOST}
+          - name: SE_EVENT_BUS_PUBLISH_PORT
+            value: ${SE_EVENT_BUS_PUBLISH_PORT}
+          - name: SE_EVENT_BUS_SUBSCRIBE_PORT
+            value: ${SE_EVENT_BUS_SUBSCRIBE_PORT}
+          image: selenium/node-chrome-debug:4.0.0
           name: master
           ports:
           - containerPort: 4444
@@ -124,3 +91,13 @@ parameters:
     description: Unique ID assigned to the node
     generate: expression
     from: '[a-z]{4}'
+  - name: SE_EVENT_BUS_HOST
+    description: The selenium event hub host
+    value: "selenium-hub"
+  - name: SE_EVENT_BUS_PUBLISH_PORT
+    description: The publish port
+    value: "4442"
+  - name: SE_EVENT_BUS_SUBSCRIBE_PORT
+    description: The subscribe port
+    value: "4443"
+    

--- a/selenium-node-chrome.yaml
+++ b/selenium-node-chrome.yaml
@@ -7,35 +7,6 @@ metadata:
     iconClass: "icon-selenium"
     tags: "selenium,node,chrome"
 objects:
-- kind: BuildConfig
-  apiVersion: v1
-  metadata:
-    name: selenium-node-chrome
-  spec:
-    triggers:
-    - type: ConfigChange
-      configChange: {}
-    source:
-      contextDir: selenium-node-chrome
-      type: Git
-      git:
-        uri: https://github.com/ddavison/selenium-openshift-templates
-        ref: master
-    strategy:
-      type: Docker
-      DockerStrategy: {}
-    output:
-      to:
-        kind: ImageStreamTag
-        name: selenium-node-chrome:latest
-- kind: ImageStream
-  apiVersion: v1
-  metadata:
-    name: selenium-node-chrome
-  spec:
-    dockerImageRepository: ''
-    tags:
-    - name: latest
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -43,16 +14,6 @@ objects:
   spec:
     strategy:
       type: Recreate
-    triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-        - master
-        from:
-          kind: ImageStreamTag
-          name: selenium-node-chrome:latest
-    - type: ConfigChange
     replicas: 1
     selector:
       browser: chrome
@@ -74,7 +35,13 @@ objects:
             value: ${HUB_PORT_4444_TCP_PORT}
           - name: REMOTE_HOST
             value: ${REMOTE_HOST}
-          image: selenium-node-chrome
+          - name: SE_EVENT_BUS_HOST
+            value: ${SE_EVENT_BUS_HOST}
+          - name: SE_EVENT_BUS_PUBLISH_PORT
+            value: ${SE_EVENT_BUS_PUBLISH_PORT}
+          - name: SE_EVENT_BUS_SUBSCRIBE_PORT
+            value: ${SE_EVENT_BUS_SUBSCRIBE_PORT}
+          image: selenium/node-chrome:4.0.0
           name: master
           ports:
           - containerPort: 4444
@@ -118,3 +85,13 @@ parameters:
     description: Unique ID assigned to the node
     generate: expression
     from: '[a-z]{4}'
+  - name: SE_EVENT_BUS_HOST
+    description: The selenium event hub host
+    value: "selenium-hub"
+  - name: SE_EVENT_BUS_PUBLISH_PORT
+    description: The publish port
+    value: "4442"
+  - name: SE_EVENT_BUS_SUBSCRIBE_PORT
+    description: The subscribe port
+    value: "4443"
+

--- a/selenium-node-firefox-debug.yaml
+++ b/selenium-node-firefox-debug.yaml
@@ -7,35 +7,6 @@ metadata:
     iconClass: "icon-selenium"
     tags: "selenium,node,firefox,vnc"
 objects:
-- kind: BuildConfig
-  apiVersion: v1
-  metadata:
-    name: selenium-node-firefox-debug
-  spec:
-    triggers:
-    - type: ConfigChange
-      configChange: {}
-    source:
-      contextDir: selenium-node-firefox-debug
-      type: Git
-      git:
-        uri: https://github.com/ddavison/selenium-openshift-templates
-        ref: master
-    strategy:
-      type: Docker
-      DockerStrategy: {}
-    output:
-      to:
-        kind: ImageStreamTag
-        name: selenium-node-firefox-debug:latest
-- kind: ImageStream
-  apiVersion: v1
-  metadata:
-    name: selenium-node-firefox-debug
-  spec:
-    dockerImageRepository: ''
-    tags:
-    - name: latest
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -43,16 +14,6 @@ objects:
   spec:
     strategy:
       type: Recreate
-    triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-        - master
-        from:
-          kind: ImageStreamTag
-          name: selenium-node-firefox-debug:latest
-    - type: ConfigChange
     replicas: 1
     selector:
       browser: firefox
@@ -74,7 +35,13 @@ objects:
             value: ${HUB_PORT_4444_TCP_PORT}
           - name: REMOTE_HOST
             value: ${REMOTE_HOST}
-          image: selenium/node-firefox-debug
+          - name: SE_EVENT_BUS_HOST
+            value: ${SE_EVENT_BUS_HOST}
+          - name: SE_EVENT_BUS_PUBLISH_PORT
+            value: ${SE_EVENT_BUS_PUBLISH_PORT}
+          - name: SE_EVENT_BUS_SUBSCRIBE_PORT
+            value: ${SE_EVENT_BUS_SUBSCRIBE_PORT}
+          image: selenium/node-firefox-debug:4.0.0
           name: master
           ports:
           - containerPort: 4444
@@ -124,3 +91,13 @@ parameters:
     description: Unique ID assigned to the node
     generate: expression
     from: '[a-z]{4}'
+  - name: SE_EVENT_BUS_HOST
+    description: The selenium event hub host
+    value: "selenium-hub"
+  - name: SE_EVENT_BUS_PUBLISH_PORT
+    description: The publish port
+    value: "4442"
+  - name: SE_EVENT_BUS_SUBSCRIBE_PORT
+    description: The subscribe port
+    value: "4443"
+    

--- a/selenium-node-firefox.yaml
+++ b/selenium-node-firefox.yaml
@@ -7,35 +7,6 @@ metadata:
     iconClass: "icon-selenium"
     tags: "selenium,node,firefox"
 objects:
-- kind: BuildConfig
-  apiVersion: v1
-  metadata:
-    name: selenium-node-firefox
-  spec:
-    triggers:
-    - type: ConfigChange
-      configChange: {}
-    source:
-      contextDir: selenium-node-firefox
-      type: Git
-      git:
-        uri: https://github.com/ddavison/selenium-openshift-templates
-        ref: master
-    strategy:
-      type: Docker
-      DockerStrategy: {}
-    output:
-      to:
-        kind: ImageStreamTag
-        name: selenium-node-firefox:latest
-- kind: ImageStream
-  apiVersion: v1
-  metadata:
-    name: selenium-node-firefox
-  spec:
-    dockerImageRepository: ''
-    tags:
-    - name: latest
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
@@ -43,16 +14,6 @@ objects:
   spec:
     strategy:
       type: Recreate
-    triggers:
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-        - master
-        from:
-          kind: ImageStreamTag
-          name: selenium-node-firefox:latest
-    - type: ConfigChange
     replicas: 1
     selector:
       browser: firefox
@@ -74,7 +35,13 @@ objects:
             value: ${HUB_PORT_4444_TCP_PORT}
           - name: REMOTE_HOST
             value: ${REMOTE_HOST}
-          image: selenium-node-firefox
+          - name: SE_EVENT_BUS_HOST
+            value: ${SE_EVENT_BUS_HOST}
+          - name: SE_EVENT_BUS_PUBLISH_PORT
+            value: ${SE_EVENT_BUS_PUBLISH_PORT}
+          - name: SE_EVENT_BUS_SUBSCRIBE_PORT
+            value: ${SE_EVENT_BUS_SUBSCRIBE_PORT}
+          image: selenium/node-firefox:4.0.0
           name: master
           ports:
           - containerPort: 4444
@@ -118,3 +85,13 @@ parameters:
     description: Unique ID assigned to the node
     generate: expression
     from: '[a-z]{4}'
+  - name: SE_EVENT_BUS_HOST
+    description: The selenium event hub host
+    value: "selenium-hub"
+  - name: SE_EVENT_BUS_PUBLISH_PORT
+    description: The publish port
+    value: "4442"
+  - name: SE_EVENT_BUS_SUBSCRIBE_PORT
+    description: The subscribe port
+    value: "4443"
+


### PR DESCRIPTION
- Updated templates to make them work with Openshift 4.5.x release and Selenium 4.0.0 release drivers.
- I deleted BuildConfig and ImeStream objects and we do not have to extend images to support ron-root user and latest images 
  support them by default.
- Updated Chrome and Firefox templates to expose required environment variables (SE_EVENT_BUS_HOST, 
   SE_EVENT_BUS_PUBLISH_PORT, SE_EVENT_BUS_SUBSCRIBE_PORT) as documented in selenium hub.
- Updated README how to create objects after deploying templates.